### PR TITLE
chore: align repo references with lion-and-bear transfer

### DIFF
--- a/.github/workflows/shared.yaml
+++ b/.github/workflows/shared.yaml
@@ -74,7 +74,7 @@ jobs:
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: pgerke/freeathome
+          slug: lion-and-bear/freeathome
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@master
         env:
@@ -112,3 +112,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_TOKEN: ${{ secrets.GITLEAKS_TOKEN }}

--- a/.github/workflows/shared.yaml
+++ b/.github/workflows/shared.yaml
@@ -112,4 +112,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_TOKEN: ${{ secrets.GITLEAKS_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: commitizen
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.8.0
+    rev: v2.11.3
     hooks:
       - id: golangci-lint
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "sonarlint.connectedMode.project": {
-    "connectionId": "pgerke",
-    "projectKey": "pgerke_freeathome"
+    "connectionId": "Lion and Bear",
+    "projectKey": "freeathome"
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Go module path**: The module is now `github.com/lion-and-bear/freeathome/v2` (repository moved to the `lion-and-bear` GitHub organization). Update `import` paths and `go get` accordingly.
+
 ## [v2.4.0] - 22.02.2026
 
 ### Changed
@@ -89,15 +95,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Set proxy device value
 - [#16] Implemented monitor application covering the scope of the [JavaScript free@home Monitor](https://github.com/pgerke/freeathome-monitor)
 
-[Unreleased]: https://github.com/pgerke/freeathome/compare/2.4.0...HEAD
-[v2.4.0]: https://github.com/pgerke/freeathome/releases/tag/2.4.0
-[v2.3.0]: https://github.com/pgerke/freeathome/releases/tag/2.3.0
-[v2.2.0]: https://github.com/pgerke/freeathome/releases/tag/2.2.0
-[v2.1.0]: https://github.com/pgerke/freeathome/releases/tag/2.1.0
-[v2.0.0]: https://github.com/pgerke/freeathome/releases/tag/2.0.0
-[v1.0.0]: https://github.com/pgerke/freeathome/releases/tag/1.0.0
-[#41]: https://github.com/pgerke/freeathome/issues/41
-[#28]: https://github.com/pgerke/freeathome/issues/28
-[#33]: https://github.com/pgerke/freeathome/issues/33
-[#7]: https://github.com/pgerke/freeathome/issues/7
-[#16]: https://github.com/pgerke/freeathome/issues/16
+[Unreleased]: https://github.com/lion-and-bear/freeathome/compare/2.4.0...HEAD
+[v2.4.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.4.0
+[v2.3.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.3.0
+[v2.2.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.2.0
+[v2.1.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.1.0
+[v2.0.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.0.0
+[v1.0.0]: https://github.com/lion-and-bear/freeathome/releases/tag/1.0.0
+[#41]: https://github.com/lion-and-bear/freeathome/issues/41
+[#28]: https://github.com/lion-and-bear/freeathome/issues/28
+[#33]: https://github.com/lion-and-bear/freeathome/issues/33
+[#7]: https://github.com/lion-and-bear/freeathome/issues/7
+[#16]: https://github.com/lion-and-bear/freeathome/issues/16

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to the free@home API Client! This do
 
 1. Clone the repository:
    ```sh
-   git clone https://github.com/pgerke/freeathome.git
+   git clone https://github.com/lion-and-bear/freeathome.git
    cd freeathome
    ```
 2. Initialize Go modules:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 A client library for the BUSCH-JAEGER free@home local API implemented in Golang.
 
-![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/pgerke/freeathome)
-![CI](https://img.shields.io/github/actions/workflow/status/pgerke/freeathome/ci.yaml?style=flat-square)
-[![codecov](https://codecov.io/gh/pgerke/freeathome/branch/main/graph/badge.svg?token=UJQVXZ5PPM)](https://codecov.io/gh/pgerke/freeathome)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pgerke_freeathome&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=pgerke_freeathome)
-![License](https://img.shields.io/github/license/pgerke/freeathome?style=flat-square)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/lion-and-bear/freeathome)
+![CI](https://img.shields.io/github/actions/workflow/status/lion-and-bear/freeathome/ci.yaml?style=flat-square)
+[![codecov](https://codecov.io/gh/lion-and-bear/freeathome/branch/main/graph/badge.svg?token=UJQVXZ5PPM)](https://codecov.io/gh/lion-and-bear/freeathome)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=lion-and-bear_freeathome&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=lion-and-bear_freeathome)
+![License](https://img.shields.io/github/license/lion-and-bear/freeathome?style=flat-square)
 
 ## Installation
 
@@ -15,13 +15,13 @@ A client library for the BUSCH-JAEGER free@home local API implemented in Golang.
 To use this library in your own Go project, make sure your project is using Go modules. Then, run the following command to add the dependency:
 
 ```sh
-go get github.com/pgerke/freeathome@latest
+go get github.com/lion-and-bear/freeathome@latest
 ```
 
 You can then import the package in your code:
 
 ```go
-import "github.com/pgerke/freeathome/v2"
+import "github.com/lion-and-bear/freeathome/v2"
 ```
 
 This will give you access to the public API client and related utilities for interacting with a local free\@home SysAP.
@@ -52,7 +52,7 @@ make cli-build-docker
 make cli-build-docker-multiarch
 
 # Run with Docker
-docker run --rm ghcr.io/pgerke/freeathome-cli:latest --help
+docker run --rm ghcr.io/lion-and-bear/freeathome-cli:latest --help
 ```
 
 #### CLI Commands
@@ -168,11 +168,11 @@ The CLI tool provides a comprehensive interface for all free@home operations:
 
 ## Documentation
 
-The API documentation is available at https://pkg.go.dev/github.com/pgerke/freeathome.
+The API documentation is available at https://pkg.go.dev/github.com/lion-and-bear/freeathome.
 
 ## I found a bug, what do I do?
 
-I'm happy to hear any feedback regarding the library or it's implementation, be it critizism, praise or rants. Please create a [GitHub issue](https://github.com/pgerke/freeathome/issues) or drop me an [email](mailto:info@philipgerke.com) if you would like to contact me.
+I'm happy to hear any feedback regarding the library or it's implementation, be it critizism, praise or rants. Please create a [GitHub issue](https://github.com/lion-and-bear/freeathome/issues) or drop me an [email](mailto:info@philipgerke.com) if you would like to contact me.
 
 I would especially appreciate, if you could report any issues you encounter while using the library. Issues I know about, I can probably fix.
 
@@ -187,7 +187,7 @@ While creating a bug report, please make it easy for me to fix it by giving us a
 
 ## I have a feature request, what do I do?
 
-Please create a [GitHub issue](https://github.com/pgerke/freeathome/issues) or drop me an [email](mailto:info@philipgerke.com)!
+Please create a [GitHub issue](https://github.com/lion-and-bear/freeathome/issues) or drop me an [email](mailto:info@philipgerke.com)!
 
 ## Non-Affiliation Disclaimer
 

--- a/cmd/cli.dockerfile
+++ b/cmd/cli.dockerfile
@@ -27,7 +27,7 @@ RUN addgroup -S app && \
 
 # === Runtime Stage (Scratch) ===
 FROM scratch
-LABEL org.opencontainers.image.source=https://github.com/pgerke/freeathome
+LABEL org.opencontainers.image.source=https://github.com/lion-and-bear/freeathome
 LABEL org.opencontainers.image.description="The free@home CLI application"
 LABEL org.opencontainers.image.licenses=MIT
 

--- a/cmd/cli/cmd/configure.go
+++ b/cmd/cli/cmd/configure.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/pgerke/freeathome/v2/internal/cli"
+	"github.com/lion-and-bear/freeathome/v2/internal/cli"
 )
 
 var (

--- a/cmd/cli/cmd/get.go
+++ b/cmd/cli/cmd/get.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/pgerke/freeathome/v2/internal/cli"
+	"github.com/lion-and-bear/freeathome/v2/internal/cli"
 )
 
 var (

--- a/cmd/cli/cmd/monitor.go
+++ b/cmd/cli/cmd/monitor.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/pgerke/freeathome/v2/internal/cli"
+	"github.com/lion-and-bear/freeathome/v2/internal/cli"
 )
 
 var (

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/pgerke/freeathome/v2/internal/cli"
+	"github.com/lion-and-bear/freeathome/v2/internal/cli"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/cmd/set.go
+++ b/cmd/cli/cmd/set.go
@@ -4,7 +4,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/pgerke/freeathome/v2/internal/cli"
+	"github.com/lion-and-bear/freeathome/v2/internal/cli"
 )
 
 var (

--- a/cmd/cli/cmd/version.go
+++ b/cmd/cli/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	internal "github.com/pgerke/freeathome/v2/internal"
+	internal "github.com/lion-and-bear/freeathome/v2/internal"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/cmd/version_test.go
+++ b/cmd/cli/cmd/version_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	internal "github.com/pgerke/freeathome/v2/internal"
+	internal "github.com/lion-and-bear/freeathome/v2/internal"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/pgerke/freeathome/v2/cmd/cli/cmd"
-	internal "github.com/pgerke/freeathome/v2/internal"
+	"github.com/lion-and-bear/freeathome/v2/cmd/cli/cmd"
+	internal "github.com/lion-and-bear/freeathome/v2/internal"
 )
 
 // version is the version of the application. The value will be overridden by the linker during the build process.

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	internal "github.com/pgerke/freeathome/v2/internal"
+	internal "github.com/lion-and-bear/freeathome/v2/internal"
 )
 
 // TestMainVersionSetting tests that the version and commit are set correctly.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pgerke/freeathome/v2
+module github.com/lion-and-bear/freeathome/v2
 
 go 1.26
 

--- a/internal/cli/get.go
+++ b/internal/cli/get.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/fatih/color"
-	"github.com/pgerke/freeathome/v2/pkg/freeathome"
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/freeathome"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 	"golang.org/x/term"
 )
 

--- a/internal/cli/get_test.go
+++ b/internal/cli/get_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/freeathome"
+	"github.com/lion-and-bear/freeathome/v2/pkg/freeathome"
 	"github.com/spf13/viper"
 )
 

--- a/internal/cli/set.go
+++ b/internal/cli/set.go
@@ -3,7 +3,7 @@ package cli
 import (
 	"fmt"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 // SetCommandConfig is a struct that contains the configuration for the set command

--- a/internal/cli/set_test.go
+++ b/internal/cli/set_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/freeathome"
+	"github.com/lion-and-bear/freeathome/v2/pkg/freeathome"
 	"github.com/spf13/viper"
 )
 

--- a/internal/cli/util_test.go
+++ b/internal/cli/util_test.go
@@ -11,7 +11,7 @@ import (
 	"log/slog"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/pgerke/freeathome/v2/pkg/freeathome"
+	"github.com/lion-and-bear/freeathome/v2/pkg/freeathome"
 	"github.com/spf13/viper"
 )
 

--- a/makefile
+++ b/makefile
@@ -24,12 +24,12 @@ cli-build:
 # Build the Docker image for the free@home CLI
 cli-build-docker:
 	@echo "Building Docker image for free@home CLI v$(VERSION) from $(COMMIT) with tag $(TAG)."
-	@docker build --build-arg version=$(VERSION) --build-arg commit=$(COMMIT) -t ghcr.io/pgerke/freeathome-cli:${TAG} -f ./cmd/cli.dockerfile .
+	@docker build --build-arg version=$(VERSION) --build-arg commit=$(COMMIT) -t ghcr.io/lion-and-bear/freeathome-cli:${TAG} -f ./cmd/cli.dockerfile .
 
 # Build the multi-arch Docker image for the free@home CLI
 cli-build-docker-multiarch:
 	@echo "Building multi-arch Docker image for free@home CLI v$(VERSION) from $(COMMIT) with tag $(TAG)."
-	@docker buildx build --platform linux/amd64,linux/arm64 --build-arg version=$(VERSION) --build-arg commit=$(COMMIT) -t ghcr.io/pgerke/freeathome-cli:${TAG} -f ./cmd/cli.dockerfile --push .
+	@docker buildx build --platform linux/amd64,linux/arm64 --build-arg version=$(VERSION) --build-arg commit=$(COMMIT) -t ghcr.io/lion-and-bear/freeathome-cli:${TAG} -f ./cmd/cli.dockerfile --push .
 
 # Run the free@home CLI integration tests
 cli-integration-test:

--- a/pkg/freeathome/sysap-websocket.go
+++ b/pkg/freeathome/sysap-websocket.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 type connection interface {

--- a/pkg/freeathome/sysap-websocket_test.go
+++ b/pkg/freeathome/sysap-websocket_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 const testMessageValid = "valid message"

--- a/pkg/freeathome/system-access-point.go
+++ b/pkg/freeathome/system-access-point.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 // Config represents the configuration for a SystemAccessPoint

--- a/pkg/freeathome/system-access-point_configuration_test.go
+++ b/pkg/freeathome/system-access-point_configuration_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 // TestSystemAccessPointGetConfiguration tests the GetConfiguration method of SystemAccessPoint.

--- a/pkg/freeathome/system-access-point_datapoint_test.go
+++ b/pkg/freeathome/system-access-point_datapoint_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 func TestSystemAccessPointGetDatapoint(t *testing.T) {

--- a/pkg/freeathome/system-access-point_device_test.go
+++ b/pkg/freeathome/system-access-point_device_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 func TestSystemAccessPointGetDevice(t *testing.T) {

--- a/pkg/freeathome/system-access-point_devicelist_test.go
+++ b/pkg/freeathome/system-access-point_devicelist_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 // TestSystemAccessPointGetDeviceList tests the GetDeviceList method of SystemAccessPoint.

--- a/pkg/freeathome/system-access-point_proxydevice_test.go
+++ b/pkg/freeathome/system-access-point_proxydevice_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 func TestSystemAccessPointTriggerProxyDevice(t *testing.T) {

--- a/pkg/freeathome/system-access-point_virtualdevice_test.go
+++ b/pkg/freeathome/system-access-point_virtualdevice_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pgerke/freeathome/v2/pkg/models"
+	"github.com/lion-and-bear/freeathome/v2/pkg/models"
 )
 
 func newVirtualDevice(t *testing.T) *models.VirtualDevice {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 # Required metadata
-sonar.projectKey=pgerke_freeathome
-sonar.organization=pgerke
+sonar.projectKey=freeathome
+sonar.organization=lion-and-bear
 sonar.projectName=free@home Golang API Client
 # The version is provided during CI as a parameter
 #sonar.projectVersion=1.0.0


### PR DESCRIPTION
## Summary

Implements the [Notion user story](https://www.notion.so/e2580c60887a4d299b3b87ef959c874f): consolidate repository references after the move to **lion-and-bear/freeathome**.

## Changes

- **Go**: `go.mod` module path `github.com/lion-and-bear/freeathome/v2` and all internal imports
- **Docs**: README, CONTRIBUTING, CHANGELOG (including **Unreleased** breaking-change note for importers)
- **CI / tooling**: Codecov slug, SonarCloud project key + org, `.vscode` SonarLint settings
- **Containers**: Makefile GHCR image names, Dockerfile `org.opencontainers.image.source`
- **Pre-commit**: golangci-lint **v2.11.3** (hooks failed on v2.8.0 with Go 1.26)

## Post-merge checklist

- [ ] Confirm **Codecov** and **SonarCloud** projects/tokens for `lion-and-bear/freeathome` (and adjust Sonar keys in UI if they differ from `lion-and-bear` / `lion-and-bear_freeathome`)
- [ ] Verify CI on `main` after merge

Ref: #61