### PR TITLE
feat(cli): add `--raw` flag to `monitor` for WebSocket JSON stream

### DIFF
--- a/.cz.yaml
+++ b/.cz.yaml
@@ -4,6 +4,6 @@ commitizen:
   name: cz_conventional_commits
   tag_format: v$version
   update_changelog_on_bump: true
-  version: 2.5.0
+  version: 2.6.0
   version_provider: commitizen
   version_scheme: semver2

--- a/.github/workflows/shared.yaml
+++ b/.github/workflows/shared.yaml
@@ -70,7 +70,7 @@ jobs:
           path: coverage.*
           retention-days: 1
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: coverage.out
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+# false positive
+pkg/freeathome/sysap-websocket_test.go:generic-api-key:25

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [#65] CLI: `monitor --raw` writes each WebSocket text frame unchanged to stdout (newline-terminated); user hints and slog output stay on stderr.
+
 ## [v2.5.0] - 22.03.2026
 
 ### Changed
@@ -104,6 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v2.1.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.1.0
 [v2.0.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.0.0
 [v1.0.0]: https://github.com/lion-and-bear/freeathome/releases/tag/1.0.0
+[#65]: https://github.com/lion-and-bear/freeathome/issues/65
 [#41]: https://github.com/lion-and-bear/freeathome/issues/41
 [#28]: https://github.com/lion-and-bear/freeathome/issues/28
 [#33]: https://github.com/lion-and-bear/freeathome/issues/33

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v2.6.0] - 03.04.2026
 
 ### Added
 
@@ -102,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Set proxy device value
 - [#16] Implemented monitor application covering the scope of the [JavaScript free@home Monitor](https://github.com/pgerke/freeathome-monitor)
 
-[Unreleased]: https://github.com/lion-and-bear/freeathome/compare/2.5.0...HEAD
+[Unreleased]: https://github.com/lion-and-bear/freeathome/compare/2.6.0...HEAD
+[v2.6.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.6.0
 [v2.5.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.5.0
 [v2.4.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.4.0
 [v2.3.0]: https://github.com/lion-and-bear/freeathome/releases/tag/2.3.0

--- a/README.md
+++ b/README.md
@@ -106,8 +106,13 @@ export FREEATHOME_PASSWORD=mypass
 ##### Real-time Monitoring
 
 ```sh
-# Monitor real-time events
+# Monitor real-time events (structured datapoint lines on stderr via logs)
 ./fh monitor
+
+# Stream raw WebSocket text frames to stdout (one JSON line per message); hints and logs on stderr
+./fh monitor --raw
+# Example: parse JSON lines (stderr shows connection logs)
+./fh monitor --raw 2>/dev/null | head -n 5
 
 # Monitor with custom settings
 ./fh monitor --timeout 60 --max-reconnection-attempts 5 --exponential-backoff

--- a/cmd/cli.dockerfile
+++ b/cmd/cli.dockerfile
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build \
   -o /app/fh /app/cmd/cli/main.go
 
 # === Bonus Stage: Create non-root user ===
-FROM alpine:3.22 AS security_provider
+FROM alpine:3.23 AS security_provider
 RUN addgroup -S app && \
     adduser -S app -G app
 

--- a/cmd/cli/cmd/monitor.go
+++ b/cmd/cli/cmd/monitor.go
@@ -12,6 +12,7 @@ var (
 	timeout                 int
 	maxReconnectionAttempts int
 	exponentialBackoff      bool
+	monitorRaw              bool
 	// Inherit common flags from other commands
 	monitorTLSEnabled    bool
 	monitorSkipTLSVerify bool
@@ -21,8 +22,9 @@ var (
 var monitorCmd = &cobra.Command{
 	Use:   "monitor",
 	Short: "Monitor the free@home system access point via WebSocket",
-	Long:  `Connect to the free@home system access point via WebSocket and monitor real-time events.`,
-	RunE:  runMonitor,
+	Long: `Connect to the free@home system access point via WebSocket and monitor real-time events.
+With --raw, each WebSocket text frame is written unchanged to stdout (one line per message); hints and logs go to stderr.`,
+	RunE: runMonitor,
 }
 
 func init() {
@@ -32,6 +34,7 @@ func init() {
 	monitorCmd.Flags().IntVar(&timeout, "timeout", 30, "WebSocket connection timeout in seconds")
 	monitorCmd.Flags().IntVar(&maxReconnectionAttempts, "max-reconnection-attempts", 3, "Maximum number of reconnection attempts before giving up")
 	monitorCmd.Flags().BoolVar(&exponentialBackoff, "exponential-backoff", true, "Enable exponential backoff between reconnection attempts")
+	monitorCmd.Flags().BoolVar(&monitorRaw, "raw", false, "Stream raw WebSocket text frames to stdout (newline-terminated); use stderr for hints and logs")
 
 	// Add TLS configuration flags
 	monitorCmd.Flags().BoolVar(&monitorTLSEnabled, "tls", true, "Enable TLS for connection")
@@ -52,5 +55,6 @@ func runMonitor(cmd *cobra.Command, args []string) error {
 		Timeout:                 timeout,
 		MaxReconnectionAttempts: maxReconnectionAttempts,
 		ExponentialBackoff:      exponentialBackoff,
+		Raw:                     monitorRaw,
 	})
 }

--- a/cmd/cli/cmd/monitor_test.go
+++ b/cmd/cli/cmd/monitor_test.go
@@ -45,6 +45,11 @@ func TestMonitorCmdFlags(t *testing.T) {
 	logLevelFlag := flags.Lookup("log-level")
 	assert.NotNil(t, logLevelFlag)
 	assert.Equal(t, "info", logLevelFlag.DefValue)
+
+	// Check raw flag
+	rawFlag := flags.Lookup("raw")
+	assert.NotNil(t, rawFlag)
+	assert.Equal(t, "false", rawFlag.DefValue)
 }
 
 func TestMonitorCmdInRoot(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pelletier/go-toml/v2 v2.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,8 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
-github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.3.0 h1:k59bC/lIZREW0/iVaQR8nDHxVq8OVlIzYCOJf421CaM=
+github.com/pelletier/go-toml/v2 v2.3.0/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -9,6 +9,8 @@ import (
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/lion-and-bear/freeathome/v2/pkg/freeathome"
 )
 
 // MonitorCommandConfig is a struct that contains the configuration for the monitor command
@@ -21,6 +23,22 @@ type MonitorCommandConfig struct {
 	Raw bool
 }
 
+// monitorConnectWebSocket runs the WebSocket loop; replaced in tests.
+var monitorConnectWebSocket = func(ctx context.Context, sysAp *freeathome.SystemAccessPoint, config MonitorCommandConfig) error {
+	timeout := time.Duration(config.Timeout) * time.Second
+	return sysAp.ConnectWebSocket(ctx, config.MaxReconnectionAttempts, config.ExponentialBackoff, timeout)
+}
+
+// applyMonitorRawMode applies the raw mode to the system access point
+func applyMonitorRawMode(sysAp *freeathome.SystemAccessPoint, raw bool) io.Writer {
+	var hintOut io.Writer = os.Stdout
+	if raw {
+		sysAp.SetWebSocketRawOutput(os.Stdout)
+		hintOut = os.Stderr
+	}
+	return hintOut
+}
+
 // Monitor connects to the free@home system access point via WebSocket and monitors real-time events
 func Monitor(config MonitorCommandConfig) error {
 	// Setup system access point
@@ -29,11 +47,8 @@ func Monitor(config MonitorCommandConfig) error {
 		return err
 	}
 
-	var hintOut io.Writer = os.Stdout
-	if config.Raw {
-		sysAp.SetWebSocketRawOutput(os.Stdout)
-		hintOut = os.Stderr
-	}
+	// Apply raw mode to the system access point
+	hintOut := applyMonitorRawMode(sysAp, config.Raw)
 
 	// Create context with cancellation for graceful shutdown
 	ctx, cancel := context.WithCancel(context.Background())
@@ -83,9 +98,8 @@ func Monitor(config MonitorCommandConfig) error {
 	_, _ = fmt.Fprintln(hintOut, "Press 'q' or Ctrl+C to exit")
 
 	// Connect to the system access point websocket
-	timeout := time.Duration(config.Timeout) * time.Second
 	go func() {
-		shutdown <- sysAp.ConnectWebSocket(ctx, config.MaxReconnectionAttempts, config.ExponentialBackoff, timeout)
+		shutdown <- monitorConnectWebSocket(ctx, sysAp, config)
 	}()
 
 	// Handle both forced shutdown and WebSocket connection errors

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -71,7 +71,8 @@ func Monitor(config MonitorCommandConfig) error {
 			default:
 				char, _, err := reader.ReadRune()
 				if err != nil {
-					break
+					// break would only exit the select; EOF or any read error must end the goroutine
+					return
 				}
 				if char == 'q' || char == 'Q' {
 					// Send SIGINT to trigger graceful shutdown

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -16,6 +17,8 @@ type MonitorCommandConfig struct {
 	Timeout                 int
 	MaxReconnectionAttempts int
 	ExponentialBackoff      bool
+	// Raw, when true, streams WebSocket text frames to stdout; user hints go to stderr.
+	Raw bool
 }
 
 // Monitor connects to the free@home system access point via WebSocket and monitors real-time events
@@ -24,6 +27,12 @@ func Monitor(config MonitorCommandConfig) error {
 	sysAp, err := setupFunc(config.CommandConfig, "")
 	if err != nil {
 		return err
+	}
+
+	var hintOut io.Writer = os.Stdout
+	if config.Raw {
+		sysAp.SetWebSocketRawOutput(os.Stdout)
+		hintOut = os.Stderr
 	}
 
 	// Create context with cancellation for graceful shutdown
@@ -61,17 +70,17 @@ func Monitor(config MonitorCommandConfig) error {
 	go func() {
 		// First signal triggers graceful shutdown
 		<-sigs
-		fmt.Println("Exit signal received, shutting down gracefully...")
-		fmt.Println("Press Ctrl+C to force exit")
+		_, _ = fmt.Fprintln(hintOut, "Exit signal received, shutting down gracefully...")
+		_, _ = fmt.Fprintln(hintOut, "Press Ctrl+C to force exit")
 		cancel()
 
 		// Second signal triggers immediate, forced shutdown
 		<-sigs
-		fmt.Println("\nSecond exit signal received, shutting down immediately...")
+		_, _ = fmt.Fprintln(hintOut, "\nSecond exit signal received, shutting down immediately...")
 		shutdown <- fmt.Errorf("forced shutdown requested")
 	}()
 
-	fmt.Println("Press 'q' or Ctrl+C to exit")
+	_, _ = fmt.Fprintln(hintOut, "Press 'q' or Ctrl+C to exit")
 
 	// Connect to the system access point websocket
 	timeout := time.Duration(config.Timeout) * time.Second

--- a/internal/cli/monitor_test.go
+++ b/internal/cli/monitor_test.go
@@ -1,10 +1,15 @@
 package cli
 
 import (
+	"context"
+	"errors"
+	"os"
 	"testing"
 
+	"github.com/lion-and-bear/freeathome/v2/pkg/freeathome"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMonitorCommandConfig(t *testing.T) {
@@ -47,4 +52,67 @@ func TestSetupMonitorWithInvalidConfig(t *testing.T) {
 	_, err := setupFunc(config.CommandConfig, "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "hostname not configured")
+}
+
+func TestApplyMonitorRawMode(t *testing.T) {
+	t.Run("raw enables stdout writer and stderr hints", func(t *testing.T) {
+		sysAp := freeathome.MustNewSystemAccessPoint(freeathome.NewConfig("localhost", "u", "p"))
+		hintOut := applyMonitorRawMode(sysAp, true)
+		assert.Equal(t, os.Stderr, hintOut)
+		assert.Equal(t, os.Stdout, sysAp.GetWebSocketRawOutput())
+	})
+	t.Run("not raw leaves writer nil and stdout hints", func(t *testing.T) {
+		sysAp := freeathome.MustNewSystemAccessPoint(freeathome.NewConfig("localhost", "u", "p"))
+		hintOut := applyMonitorRawMode(sysAp, false)
+		assert.Equal(t, os.Stdout, hintOut)
+		assert.Nil(t, sysAp.GetWebSocketRawOutput())
+	})
+}
+
+func TestMonitorWithMockConnect(t *testing.T) {
+	oldConn := monitorConnectWebSocket
+	t.Cleanup(func() { monitorConnectWebSocket = oldConn })
+	oldSetup := setupFunc
+	t.Cleanup(func() { setupFunc = oldSetup })
+
+	baseCfg := func(raw bool) MonitorCommandConfig {
+		return MonitorCommandConfig{
+			CommandConfig: CommandConfig{
+				Viper:         viper.New(),
+				TLSEnabled:    false,
+				SkipTLSVerify: false,
+				LogLevel:      "info",
+			},
+			Timeout:                 30,
+			MaxReconnectionAttempts: 1,
+			ExponentialBackoff:      false,
+			Raw:                     raw,
+		}
+	}
+
+	t.Run("raw sets WebSocket output", func(t *testing.T) {
+		sysAp := freeathome.MustNewSystemAccessPoint(freeathome.NewConfig("localhost", "u", "p"))
+		setupFunc = func(CommandConfig, string) (*freeathome.SystemAccessPoint, error) {
+			return sysAp, nil
+		}
+		monitorConnectWebSocket = func(ctx context.Context, sa *freeathome.SystemAccessPoint, c MonitorCommandConfig) error {
+			return nil
+		}
+		err := Monitor(baseCfg(true))
+		require.NoError(t, err)
+		assert.Equal(t, os.Stdout, sysAp.GetWebSocketRawOutput())
+	})
+
+	t.Run("connect error propagates", func(t *testing.T) {
+		sysAp := freeathome.MustNewSystemAccessPoint(freeathome.NewConfig("localhost", "u", "p"))
+		setupFunc = func(CommandConfig, string) (*freeathome.SystemAccessPoint, error) {
+			return sysAp, nil
+		}
+		monitorConnectWebSocket = func(ctx context.Context, sa *freeathome.SystemAccessPoint, c MonitorCommandConfig) error {
+			return errors.New("dial refused")
+		}
+		err := Monitor(baseCfg(false))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dial refused")
+	})
 }

--- a/internal/cli/monitor_test.go
+++ b/internal/cli/monitor_test.go
@@ -19,6 +19,7 @@ func TestMonitorCommandConfig(t *testing.T) {
 		Timeout:                 30,
 		MaxReconnectionAttempts: 3,
 		ExponentialBackoff:      true,
+		Raw:                     false,
 	}
 
 	assert.NotNil(t, config.Viper)
@@ -28,6 +29,7 @@ func TestMonitorCommandConfig(t *testing.T) {
 	assert.Equal(t, 30, config.Timeout)
 	assert.Equal(t, 3, config.MaxReconnectionAttempts)
 	assert.True(t, config.ExponentialBackoff)
+	assert.False(t, config.Raw)
 }
 
 func TestSetupMonitorWithInvalidConfig(t *testing.T) {

--- a/pkg/freeathome/sysap-websocket.go
+++ b/pkg/freeathome/sysap-websocket.go
@@ -216,7 +216,9 @@ func (ws *SystemAccessPointWebSocket) webSocketMessageLoop(ctx context.Context, 
 			}
 
 			// Pipe the message to the message handler
-			ws.sysAp.config.Logger.Debug("received text message from web socket")
+			if ws.sysAp.config.WebSocketRawOutput == nil {
+				ws.sysAp.config.Logger.Debug("received text message from web socket")
+			}
 			select {
 			case webSocketMessageChannel <- message:
 				// Message sent successfully
@@ -296,6 +298,15 @@ func (ws *SystemAccessPointWebSocket) processMessage(message []byte) {
 			ws.onMessageHandled()
 		}
 	}()
+
+	if w := ws.sysAp.config.WebSocketRawOutput; w != nil {
+		out := append(append([]byte(nil), message...), '\n')
+		if _, err := w.Write(out); err != nil {
+			ws.sysAp.config.Logger.Error("failed to write raw web socket message", "error", err)
+			ws.sysAp.emitError(err)
+		}
+		return
+	}
 
 	// Unmarshal the message into a WebSocketMessage struct
 	var msg models.WebSocketMessage

--- a/pkg/freeathome/sysap-websocket_test.go
+++ b/pkg/freeathome/sysap-websocket_test.go
@@ -1,6 +1,7 @@
 package freeathome
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -95,6 +96,47 @@ func TestSystemAccessPointWebSocketMessageHandler(t *testing.T) {
 	// Verify invalid format message handling
 	if !strings.Contains(logOutput, "Ignored datapoint with invalid key format") {
 		t.Errorf("Expected log output to contain 'Ignored datapoint with invalid key format', got: %s", logOutput)
+	}
+}
+
+func TestProcessMessageWebSocketRawOutput(t *testing.T) {
+	ws, buf, _ := setupSysApWebSocket(t, true, false)
+
+	var rawBuf bytes.Buffer
+	ws.sysAp.SetWebSocketRawOutput(&rawBuf)
+
+	validMessage := models.WebSocketMessage{
+		models.EmptyUUID: models.Message{
+			Datapoints: map[string]string{
+				"ABB7F595EC47/ch0000/odp0000": "1",
+			},
+		},
+	}
+	validMessageBytes, err := json.Marshal(validMessage)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	ws.processMessage(validMessageBytes)
+
+	want := string(validMessageBytes) + "\n"
+	if rawBuf.String() != want {
+		t.Errorf("raw output: got %q want %q", rawBuf.String(), want)
+	}
+	logOutput := buf.String()
+	if strings.Contains(logOutput, "data point update") {
+		t.Errorf("expected no datapoint log in raw mode, got: %s", logOutput)
+	}
+
+	// Invalid JSON is still written as-is; no unmarshal error log in raw mode
+	rawBuf.Reset()
+	buf.Reset()
+	ws.processMessage([]byte(`not json`))
+	if rawBuf.String() != "not json\n" {
+		t.Errorf("raw invalid JSON: got %q", rawBuf.String())
+	}
+	if strings.Contains(buf.String(), "failed to unmarshal message") {
+		t.Errorf("expected no unmarshal error log in raw mode, got: %s", buf.String())
 	}
 }
 

--- a/pkg/freeathome/sysap-websocket_test.go
+++ b/pkg/freeathome/sysap-websocket_test.go
@@ -20,6 +20,47 @@ import (
 
 const testMessageValid = "valid message"
 
+// Duplicated (or production-matched) literals for assertions — keep in sync with sysap-websocket.go log/error text.
+const (
+	testDatapointKeyValid = "ABB7F595EC47/ch0000/odp0000"
+
+	logMsgDataPointUpdate             = "data point update"
+	logMsgFailedUnmarshal             = "failed to unmarshal message"
+	logMsgNoDatapoints                = "web socket message has no datapoints"
+	logMsgIgnoredInvalidDatapointKey  = "Ignored datapoint with invalid key format"
+	logMsgFailedWriteRaw              = "failed to write raw web socket message"
+	logMsgReceivedTextMessage         = "received text message from web socket"
+	logMsgWebSocketConnected          = "web socket connected successfully"
+	logMsgTLSNotRecommended           = "this is not recommended"
+	logMsgWebSocketMessageHandlerDone = "webSocketMessageChannel closed, stopping message handler"
+	logMsgContextCancelledWSAttempts  = "context cancelled, stopping web socket connection attempts"
+	logMsgFailedConnectWebSocket      = "failed to connect to web socket"
+	logMsgMaxReconnectionExceeded     = "maximum reconnection attempts exceeded"
+	logMsgReceivedNonText             = "received non-text message from web socket"
+	logMsgKeepalivePing               = "keepalive timer expired, sending ping"
+	logMsgWebSocketMessageChannelNil  = "webSocketMessageChannel is nil"
+	logMsgMessageReceivedChannelNil   = "messageReceivedChannel is nil, cannot start keepalive loop"
+
+	errMsgConnectionChannelNil       = "a connection channel is nil, cannot start message loop"
+	errMsgWriteFailed                = "write failed"
+	errMsgNoMoreMessages             = "no more messages"
+	errMsgExpectedLogOutputToContain = "Expected log output to contain %q, got: %s"
+	errMsgWebSocketUpgradeFailed     = "Failed to upgrade WebSocket: %v"
+	errMsgExpectedNoErrorGot         = "Expected no error, got: %v"
+	errMsgUnexpectedErrorGot         = "Unexpected error: %v"
+
+	lookupInvalidHostSubstr = "lookup invalid-host"
+
+	invalidHost        = "invalid-host"
+	invalidJSONPayload = "invalid json"
+	notJSONPayload     = "not json"
+)
+
+const (
+	wsURLHTTP  = "ws://localhost/fhapi/v1/api/ws"
+	wsURLHTTPS = "wss://localhost/fhapi/v1/api/ws"
+)
+
 // TestSystemAccessPointWebSocketMessageHandler tests the webSocketMessageHandler method of SystemAccessPoint.
 func TestSystemAccessPointWebSocketMessageHandler(t *testing.T) {
 	ws, buf, _ := setupSysApWebSocket(t, true, false)
@@ -31,14 +72,14 @@ func TestSystemAccessPointWebSocketMessageHandler(t *testing.T) {
 	validMessage := models.WebSocketMessage{
 		models.EmptyUUID: models.Message{
 			Datapoints: map[string]string{
-				"ABB7F595EC47/ch0000/odp0000": "1",
+				testDatapointKeyValid: "1",
 			},
 		},
 	}
 	validMessageBytes, _ := json.Marshal(validMessage)
 
 	// Mock an invalid WebSocketMessage
-	invalidMessage := []byte(`invalid json`)
+	invalidMessage := []byte(invalidJSONPayload)
 
 	// Mock a WebSocketMessage with no datapoints
 	emptyMessage := models.WebSocketMessage{
@@ -79,23 +120,23 @@ func TestSystemAccessPointWebSocketMessageHandler(t *testing.T) {
 	logOutput := buf.String()
 
 	// Verify valid message processing
-	if !strings.Contains(logOutput, "data point update") {
-		t.Errorf("Expected log output to contain 'data point update', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgDataPointUpdate) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgDataPointUpdate, logOutput)
 	}
 
 	// Verify invalid message handling
-	if !strings.Contains(logOutput, "failed to unmarshal message") {
-		t.Errorf("Expected log output to contain 'failed to unmarshal message', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgFailedUnmarshal) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgFailedUnmarshal, logOutput)
 	}
 
 	// Verify empty message handling
-	if !strings.Contains(logOutput, "web socket message has no datapoints") {
-		t.Errorf("Expected log output to contain 'web socket message has no datapoints', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgNoDatapoints) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgNoDatapoints, logOutput)
 	}
 
 	// Verify invalid format message handling
-	if !strings.Contains(logOutput, "Ignored datapoint with invalid key format") {
-		t.Errorf("Expected log output to contain 'Ignored datapoint with invalid key format', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgIgnoredInvalidDatapointKey) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgIgnoredInvalidDatapointKey, logOutput)
 	}
 }
 
@@ -104,7 +145,7 @@ func TestProcessMessageWebSocketRawOutputWriteError(t *testing.T) {
 
 	errSeen := 0
 	ws.sysAp.onError = func(err error) {
-		if err != nil && err.Error() == "write failed" {
+		if err != nil && err.Error() == errMsgWriteFailed {
 			errSeen++
 		}
 	}
@@ -115,7 +156,7 @@ func TestProcessMessageWebSocketRawOutputWriteError(t *testing.T) {
 		t.Errorf("expected onError once for write failure, got %d", errSeen)
 	}
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "failed to write raw web socket message") {
+	if !strings.Contains(logOutput, logMsgFailedWriteRaw) {
 		t.Errorf("expected log about raw write failure, got: %s", logOutput)
 	}
 }
@@ -123,7 +164,7 @@ func TestProcessMessageWebSocketRawOutputWriteError(t *testing.T) {
 type failWriter struct{}
 
 func (failWriter) Write(_ []byte) (n int, err error) {
-	return 0, errors.New("write failed")
+	return 0, errors.New(errMsgWriteFailed)
 }
 
 func TestWebSocketMessageLoopTextMessageRawSkipsDebugLog(t *testing.T) {
@@ -161,7 +202,7 @@ func TestWebSocketMessageLoopTextMessageRawSkipsDebugLog(t *testing.T) {
 	}
 
 	logOutput := buf.String()
-	if strings.Contains(logOutput, "received text message from web socket") {
+	if strings.Contains(logOutput, logMsgReceivedTextMessage) {
 		t.Errorf("did not expect debug log when raw output is set, got: %s", logOutput)
 	}
 }
@@ -175,7 +216,7 @@ func TestProcessMessageWebSocketRawOutput(t *testing.T) {
 	validMessage := models.WebSocketMessage{
 		models.EmptyUUID: models.Message{
 			Datapoints: map[string]string{
-				"ABB7F595EC47/ch0000/odp0000": "1",
+				testDatapointKeyValid: "1",
 			},
 		},
 	}
@@ -191,18 +232,18 @@ func TestProcessMessageWebSocketRawOutput(t *testing.T) {
 		t.Errorf("raw output: got %q want %q", rawBuf.String(), want)
 	}
 	logOutput := buf.String()
-	if strings.Contains(logOutput, "data point update") {
+	if strings.Contains(logOutput, logMsgDataPointUpdate) {
 		t.Errorf("expected no datapoint log in raw mode, got: %s", logOutput)
 	}
 
 	// Invalid JSON is still written as-is; no unmarshal error log in raw mode
 	rawBuf.Reset()
 	buf.Reset()
-	ws.processMessage([]byte(`not json`))
-	if rawBuf.String() != "not json\n" {
+	ws.processMessage([]byte(notJSONPayload))
+	if rawBuf.String() != notJSONPayload+"\n" {
 		t.Errorf("raw invalid JSON: got %q", rawBuf.String())
 	}
-	if strings.Contains(buf.String(), "failed to unmarshal message") {
+	if strings.Contains(buf.String(), logMsgFailedUnmarshal) {
 		t.Errorf("expected no unmarshal error log in raw mode, got: %s", buf.String())
 	}
 }
@@ -217,8 +258,8 @@ func TestSystemAccessPointWebSocketMessageHandlerMissingChannel(t *testing.T) {
 	// Check the log output
 	logOutput := buf.String()
 
-	if !strings.Contains(logOutput, "webSocketMessageChannel is nil") {
-		t.Errorf("Expected log output to contain 'webSocketMessageChannel is nil', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgWebSocketMessageChannelNil) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgWebSocketMessageChannelNil, logOutput)
 	}
 }
 
@@ -243,7 +284,7 @@ func TestSystemAccessPointConnectWebSocketSuccess(t *testing.T) {
 		conn, err = upgrader.Upgrade(w, r, nil)
 		connMutex.Unlock()
 		if err != nil {
-			t.Fatalf("Failed to upgrade WebSocket: %v", err)
+			t.Fatalf(errMsgWebSocketUpgradeFailed, err)
 		}
 	}))
 	defer server.Close()
@@ -257,7 +298,7 @@ func TestSystemAccessPointConnectWebSocketSuccess(t *testing.T) {
 			case <-ctx.Done():
 				return
 			case record := <-records:
-				if record.Level == slog.LevelInfo && strings.Contains(record.Message, "web socket connected successfully") {
+				if record.Level == slog.LevelInfo && strings.Contains(record.Message, logMsgWebSocketConnected) {
 					cancel()
 					connMutex.Lock()
 					if conn != nil {
@@ -272,7 +313,7 @@ func TestSystemAccessPointConnectWebSocketSuccess(t *testing.T) {
 	// Run ConnectWebSocket in a separate goroutine
 	err := sysAp.ConnectWebSocket(ctx, 1, false, 1*time.Hour)
 	if err != nil && err != context.Canceled {
-		t.Errorf("Expected no error, got: %v", err)
+		t.Errorf(errMsgExpectedNoErrorGot, err)
 	}
 }
 
@@ -297,7 +338,7 @@ func TestSystemAccessPointConnectWebSocketSkipTlsVerify(t *testing.T) {
 		conn, err = upgrader.Upgrade(w, r, nil)
 		connMutex.Unlock()
 		if err != nil {
-			t.Fatalf("Failed to upgrade WebSocket: %v", err)
+			t.Fatalf(errMsgWebSocketUpgradeFailed, err)
 		}
 	}))
 	defer server.Close()
@@ -311,12 +352,12 @@ func TestSystemAccessPointConnectWebSocketSkipTlsVerify(t *testing.T) {
 			case <-ctx.Done():
 				// Check the log output safely
 				logOutput := buf.String()
-				if !strings.Contains(logOutput, "this is not recommended") {
-					t.Errorf("Expected log output to contain 'this is not recommended', got: %s", logOutput)
+				if !strings.Contains(logOutput, logMsgTLSNotRecommended) {
+					t.Errorf(errMsgExpectedLogOutputToContain, logMsgTLSNotRecommended, logOutput)
 				}
 				return
 			case record := <-records:
-				if record.Level == slog.LevelInfo && strings.Contains(record.Message, "web socket connected successfully") {
+				if record.Level == slog.LevelInfo && strings.Contains(record.Message, logMsgWebSocketConnected) {
 					cancel()
 					connMutex.Lock()
 					if conn != nil {
@@ -331,7 +372,7 @@ func TestSystemAccessPointConnectWebSocketSkipTlsVerify(t *testing.T) {
 	// Run ConnectWebSocket in a separate goroutine
 	err := sysAp.ConnectWebSocket(ctx, 1, false, 1*time.Hour)
 	if err != nil && err != context.Canceled {
-		t.Errorf("Expected no error, got: %v", err)
+		t.Errorf(errMsgExpectedNoErrorGot, err)
 	}
 }
 
@@ -355,7 +396,7 @@ func TestSystemAccessPointConnectWebSocketContextCancelled(t *testing.T) {
 		conn, err = upgrader.Upgrade(w, r, nil)
 		connMutex.Unlock()
 		if err != nil {
-			t.Fatalf("Failed to upgrade WebSocket: %v", err)
+			t.Fatalf(errMsgWebSocketUpgradeFailed, err)
 		}
 	}))
 	defer server.Close()
@@ -373,7 +414,7 @@ func TestSystemAccessPointConnectWebSocketContextCancelled(t *testing.T) {
 				return
 			case record := <-records:
 				// Cancel the context when the web socket is connected successfully
-				if record.Level == slog.LevelInfo && strings.Contains(record.Message, "web socket connected successfully") {
+				if record.Level == slog.LevelInfo && strings.Contains(record.Message, logMsgWebSocketConnected) {
 					cancel()
 					connMutex.Lock()
 					if conn != nil {
@@ -383,12 +424,12 @@ func TestSystemAccessPointConnectWebSocketContextCancelled(t *testing.T) {
 					break
 				}
 				// Send one done when the message handler is stopped
-				if record.Level == slog.LevelInfo && strings.Contains(record.Message, "webSocketMessageChannel closed, stopping message handler") {
+				if record.Level == slog.LevelInfo && strings.Contains(record.Message, logMsgWebSocketMessageHandlerDone) {
 					wg.Done()
 					break
 				}
 				// Send one done when the web socket connection is stopped
-				if record.Level == slog.LevelInfo && strings.Contains(record.Message, "context cancelled, stopping web socket connection attempts") {
+				if record.Level == slog.LevelInfo && strings.Contains(record.Message, logMsgContextCancelledWSAttempts) {
 					wg.Done()
 				}
 			}
@@ -399,7 +440,7 @@ func TestSystemAccessPointConnectWebSocketContextCancelled(t *testing.T) {
 	go func() {
 		err := sysAp.ConnectWebSocket(ctx, 1, false, 1*time.Hour)
 		if err != nil && err != context.Canceled {
-			t.Errorf("Expected no error, got: %v", err)
+			t.Errorf(errMsgExpectedNoErrorGot, err)
 		}
 	}()
 
@@ -417,14 +458,14 @@ func TestSystemAccessPointConnectWebSocketFailure(t *testing.T) {
 	sysAp, buf, _ := setupSysAp(t, false, false)
 
 	// Set an invalid host name to simulate connection failure
-	sysAp.config.Hostname = "invalid-host"
+	sysAp.config.Hostname = invalidHost
 
 	// set up the error handler
 	sysAp.onError = func(err error) {
-		if strings.Contains(err.Error(), "lookup invalid-host") {
+		if strings.Contains(err.Error(), lookupInvalidHostSubstr) {
 			cancel()
 		} else {
-			t.Errorf("Unexpected error: %v", err)
+			t.Errorf(errMsgUnexpectedErrorGot, err)
 		}
 	}
 
@@ -432,7 +473,7 @@ func TestSystemAccessPointConnectWebSocketFailure(t *testing.T) {
 	go func() {
 		err := sysAp.ConnectWebSocket(ctx, 1, false, 1*time.Hour)
 		if err != nil && err != context.Canceled {
-			t.Errorf("Expected no error, got: %v", err)
+			t.Errorf(errMsgExpectedNoErrorGot, err)
 		}
 	}()
 
@@ -441,8 +482,8 @@ func TestSystemAccessPointConnectWebSocketFailure(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "failed to connect to web socket") {
-		t.Errorf("Expected log output to contain 'failed to connect to web socket', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgFailedConnectWebSocket) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgFailedConnectWebSocket, logOutput)
 	}
 }
 
@@ -455,14 +496,14 @@ func TestSystemAccessPointConnectWebSocketFailureWithBackoff(t *testing.T) {
 	sysAp.clock = &fakeClock{}
 
 	// Set an invalid host name to simulate connection failure
-	sysAp.config.Hostname = "invalid-host"
+	sysAp.config.Hostname = invalidHost
 
 	// set up the error handler
 	sysAp.onError = func(err error) {
-		if strings.Contains(err.Error(), "lookup invalid-host") {
+		if strings.Contains(err.Error(), lookupInvalidHostSubstr) {
 			cancel()
 		} else {
-			t.Errorf("Unexpected error: %v", err)
+			t.Errorf(errMsgUnexpectedErrorGot, err)
 		}
 	}
 
@@ -470,7 +511,7 @@ func TestSystemAccessPointConnectWebSocketFailureWithBackoff(t *testing.T) {
 	go func() {
 		err := sysAp.ConnectWebSocket(ctx, 3, true, 1*time.Hour)
 		if err != nil && err != context.Canceled {
-			t.Errorf("Expected no error, got: %v", err)
+			t.Errorf(errMsgExpectedNoErrorGot, err)
 		}
 	}()
 
@@ -479,8 +520,8 @@ func TestSystemAccessPointConnectWebSocketFailureWithBackoff(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "failed to connect to web socket") {
-		t.Errorf("Expected log output to contain 'failed to connect to web socket', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgFailedConnectWebSocket) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgFailedConnectWebSocket, logOutput)
 	}
 }
 
@@ -488,7 +529,7 @@ func TestSystemAccessPointConnectWebSocketMaxReconnectionAttempts(t *testing.T) 
 	sysAp, buf, _ := setupSysAp(t, false, false)
 
 	// Set an invalid host name to simulate connection failure
-	sysAp.config.Hostname = "invalid-host"
+	sysAp.config.Hostname = invalidHost
 
 	// set up the error handler
 	errorCount := 0
@@ -500,8 +541,8 @@ func TestSystemAccessPointConnectWebSocketMaxReconnectionAttempts(t *testing.T) 
 	err := sysAp.ConnectWebSocket(t.Context(), 2, false, 1*time.Hour)
 
 	// Verify error
-	if err == nil || err.Error() != "maximum reconnection attempts exceeded" {
-		t.Errorf("Expected error 'maximum reconnection attempts exceeded', got: %v", err)
+	if err == nil || err.Error() != logMsgMaxReconnectionExceeded {
+		t.Errorf("Expected error %q, got: %v", logMsgMaxReconnectionExceeded, err)
 	}
 
 	// Verify the error count (should be 2 failed attempts)
@@ -511,8 +552,8 @@ func TestSystemAccessPointConnectWebSocketMaxReconnectionAttempts(t *testing.T) 
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "maximum reconnection attempts exceeded") {
-		t.Errorf("Expected log output to contain 'maximum reconnection attempts exceeded', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgMaxReconnectionExceeded) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgMaxReconnectionExceeded, logOutput)
 	}
 }
 
@@ -555,8 +596,8 @@ func TestSystemAccessPointWebSocketMessageLoopTextMessage(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "received text message from web socket") {
-		t.Errorf("Expected log output to contain 'received text message from web socket', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgReceivedTextMessage) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgReceivedTextMessage, logOutput)
 	}
 }
 
@@ -569,10 +610,10 @@ func TestSystemAccessPointWebSocketMessageLoopNonTextMessage(t *testing.T) {
 	webSocketMessageChannel := make(chan []byte, 10)
 	messageReceivedChannel := make(chan struct{}, 1)
 	ws.sysAp.onError = func(err error) {
-		if strings.Contains(err.Error(), "no more messages") {
+		if strings.Contains(err.Error(), errMsgNoMoreMessages) {
 			cancel()
 		} else {
-			t.Errorf("Unexpected error: %v", err)
+			t.Errorf(errMsgUnexpectedErrorGot, err)
 		}
 	}
 
@@ -602,8 +643,8 @@ func TestSystemAccessPointWebSocketMessageLoopNonTextMessage(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "received non-text message from web socket") {
-		t.Errorf("Expected log output to contain 'received non-text message from web socket', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgReceivedNonText) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgReceivedNonText, logOutput)
 	}
 }
 
@@ -628,8 +669,8 @@ func TestSystemAccessPointWebSocketMessageLoopMissingChannel(t *testing.T) {
 		t.Error(expectedErrorGotNil)
 	}
 	// Check if the error is due to the missing channel
-	if !strings.Contains(err.Error(), "a connection channel is nil, cannot start message loop") {
-		t.Errorf("Expected error 'a connection channel is nil, cannot start message loop', got: %v", err)
+	if !strings.Contains(err.Error(), errMsgConnectionChannelNil) {
+		t.Errorf("Expected error %q, got: %v", errMsgConnectionChannelNil, err)
 	}
 
 	// Wait for the context to be done
@@ -639,8 +680,8 @@ func TestSystemAccessPointWebSocketMessageLoopMissingChannel(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "a connection channel is nil, cannot start message loop") {
-		t.Errorf("Expected log output to contain 'a connection channel is nil, cannot start message loop', got: %s", logOutput)
+	if !strings.Contains(logOutput, errMsgConnectionChannelNil) {
+		t.Errorf(errMsgExpectedLogOutputToContain, errMsgConnectionChannelNil, logOutput)
 	}
 }
 
@@ -661,8 +702,8 @@ func TestSystemAccessPointWebSocketKeepaliveLoopMissingChannel(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "essageReceivedChannel is nil, cannot start keepalive loop") {
-		t.Errorf("Expected log output to contain 'essageReceivedChannel is nil, cannot start keepalive loop', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgMessageReceivedChannelNil) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgMessageReceivedChannelNil, logOutput)
 	}
 }
 
@@ -702,8 +743,8 @@ func TestSystemAccessPointWebSocketKeepaliveLoopSendPing(t *testing.T) {
 
 	// Check the log output safely
 	logOutput := buf.String()
-	if !strings.Contains(logOutput, "keepalive timer expired, sending ping") {
-		t.Errorf("Expected log output to contain 'keepalive timer expired, sending ping', got: %s", logOutput)
+	if !strings.Contains(logOutput, logMsgKeepalivePing) {
+		t.Errorf(errMsgExpectedLogOutputToContain, logMsgKeepalivePing, logOutput)
 	}
 
 	// Check if the ping message was sent safely
@@ -720,7 +761,6 @@ func TestSystemAccessPointGetWsUrlWithoutTls(t *testing.T) {
 	ws, buf, _ := setupSysApWebSocket(t, false, false)
 
 	actual := ws.getWebSocketUrl()
-	expected := "ws://localhost/fhapi/v1/api/ws"
 
 	// Check if the log output is empty
 	logOutput := buf.String()
@@ -729,8 +769,8 @@ func TestSystemAccessPointGetWsUrlWithoutTls(t *testing.T) {
 	}
 
 	// Check if the actual URL matches the expected URL
-	if actual != expected {
-		t.Errorf("Expected URL '%s', got '%s'", expected, actual)
+	if actual != wsURLHTTP {
+		t.Errorf("Expected URL '%s', got '%s'", wsURLHTTP, actual)
 	}
 }
 
@@ -739,7 +779,6 @@ func TestSystemAccessPointGetWsUrlWithTls(t *testing.T) {
 	ws, buf, _ := setupSysApWebSocket(t, true, false)
 
 	actual := ws.getWebSocketUrl()
-	expected := "wss://localhost/fhapi/v1/api/ws"
 
 	// Check if the log output is empty
 	logOutput := buf.String()
@@ -748,8 +787,8 @@ func TestSystemAccessPointGetWsUrlWithTls(t *testing.T) {
 	}
 
 	// Check if the actual URL matches the expected URL
-	if actual != expected {
-		t.Errorf("Expected URL '%s', got '%s'", expected, actual)
+	if actual != wsURLHTTPS {
+		t.Errorf("Expected URL '%s', got '%s'", wsURLHTTPS, actual)
 	}
 }
 

--- a/pkg/freeathome/sysap-websocket_test.go
+++ b/pkg/freeathome/sysap-websocket_test.go
@@ -99,6 +99,73 @@ func TestSystemAccessPointWebSocketMessageHandler(t *testing.T) {
 	}
 }
 
+func TestProcessMessageWebSocketRawOutputWriteError(t *testing.T) {
+	ws, buf, _ := setupSysApWebSocket(t, true, false)
+
+	errSeen := 0
+	ws.sysAp.onError = func(err error) {
+		if err != nil && err.Error() == "write failed" {
+			errSeen++
+		}
+	}
+	ws.sysAp.SetWebSocketRawOutput(failWriter{})
+	ws.processMessage([]byte(`{}`))
+
+	if errSeen != 1 {
+		t.Errorf("expected onError once for write failure, got %d", errSeen)
+	}
+	logOutput := buf.String()
+	if !strings.Contains(logOutput, "failed to write raw web socket message") {
+		t.Errorf("expected log about raw write failure, got: %s", logOutput)
+	}
+}
+
+type failWriter struct{}
+
+func (failWriter) Write(_ []byte) (n int, err error) {
+	return 0, errors.New("write failed")
+}
+
+func TestWebSocketMessageLoopTextMessageRawSkipsDebugLog(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	ws, buf, _ := setupSysApWebSocket(t, true, false)
+	ws.sysAp.SetWebSocketRawOutput(&bytes.Buffer{})
+
+	webSocketMessageChannel := make(chan []byte, 10)
+	messageReceivedChannel := make(chan struct{}, 1)
+
+	conn := &MockConn{
+		messageType: websocket.TextMessage,
+		r:           []byte(testMessageValid),
+		err:         nil,
+	}
+
+	go func() {
+		err := ws.webSocketMessageLoop(ctx, messageReceivedChannel, webSocketMessageChannel, conn)
+		if err == nil {
+			t.Error(expectedErrorGotNil)
+		}
+	}()
+
+	message := <-webSocketMessageChannel
+	cancel()
+	<-ctx.Done()
+	close(webSocketMessageChannel)
+	close(messageReceivedChannel)
+	ws.waitGroup.Wait()
+
+	if string(message) != testMessageValid {
+		t.Errorf("Expected message %q, got: %s", testMessageValid, string(message))
+	}
+
+	logOutput := buf.String()
+	if strings.Contains(logOutput, "received text message from web socket") {
+		t.Errorf("did not expect debug log when raw output is set, got: %s", logOutput)
+	}
+}
+
 func TestProcessMessageWebSocketRawOutput(t *testing.T) {
 	ws, buf, _ := setupSysApWebSocket(t, true, false)
 

--- a/pkg/freeathome/system-access-point.go
+++ b/pkg/freeathome/system-access-point.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"regexp"
 
 	"github.com/go-resty/resty/v2"
@@ -30,6 +31,9 @@ type Config struct {
 	Logger models.Logger
 	// Client is the REST client to use (optional, will create default if nil)
 	Client *resty.Client
+	// WebSocketRawOutput, when non-nil, receives each WebSocket text frame as written on the wire
+	// plus a trailing newline; datapoint parsing and structured logs for that frame are skipped.
+	WebSocketRawOutput io.Writer
 }
 
 // NewConfig creates a new Config with default values
@@ -134,6 +138,12 @@ func (sysAp *SystemAccessPoint) GetSkipTLSVerify() bool {
 // VerboseErrors returns whether verbose errors should be logged.
 func (sysAp *SystemAccessPoint) GetVerboseErrors() bool {
 	return sysAp.config.VerboseErrors
+}
+
+// SetWebSocketRawOutput sets the writer that receives raw WebSocket text frames (see Config.WebSocketRawOutput).
+// Pass nil to disable.
+func (sysAp *SystemAccessPoint) SetWebSocketRawOutput(w io.Writer) {
+	sysAp.config.WebSocketRawOutput = w
 }
 
 // GetUrl constructs a URL string for the SystemAccessPoint based on the provided path.

--- a/pkg/freeathome/system-access-point.go
+++ b/pkg/freeathome/system-access-point.go
@@ -146,6 +146,11 @@ func (sysAp *SystemAccessPoint) SetWebSocketRawOutput(w io.Writer) {
 	sysAp.config.WebSocketRawOutput = w
 }
 
+// GetWebSocketRawOutput returns the configured writer for raw WebSocket text frames, or nil if disabled.
+func (sysAp *SystemAccessPoint) GetWebSocketRawOutput() io.Writer {
+	return sysAp.config.WebSocketRawOutput
+}
+
 // GetUrl constructs a URL string for the SystemAccessPoint based on the provided path.
 // It uses the appropriate protocol (http or https) depending on whether TLS is enabled.
 //
@@ -237,7 +242,7 @@ func (sysAp *SystemAccessPoint) GetDevice(serial string) (*models.DeviceResponse
 //
 //	*models.Datapoint - The retrieved datapoint object.
 //	error             - An error if the request or parsing fails.
-func (sysAp *SystemAccessPoint) GetDatapoint(serial string, channel string, datapoint string) (*models.GetDataPointResponse, error) {
+func (sysAp *SystemAccessPoint) GetDatapoint(serial, channel, datapoint string) (*models.GetDataPointResponse, error) {
 	resp, err := sysAp.config.Client.R().
 		SetPathParams(map[string]string{"uuid": sysAp.UUID, "serial": serial, "channel": channel, "datapoint": datapoint}).
 		Get(sysAp.GetUrl("datapoint/{uuid}/{serial}.{channel}.{datapoint}"))
@@ -259,7 +264,7 @@ func (sysAp *SystemAccessPoint) GetDatapoint(serial string, channel string, data
 //
 //	*models.SetDataPointResponse - The response from the SysAP after setting the datapoint.
 //	error                        - An error if the request fails or the response cannot be parsed.
-func (sysAp *SystemAccessPoint) SetDatapoint(serial string, channel string, datapoint string, value string) (*models.SetDataPointResponse, error) {
+func (sysAp *SystemAccessPoint) SetDatapoint(serial, channel, datapoint, value string) (*models.SetDataPointResponse, error) {
 	resp, err := sysAp.config.Client.R().
 		SetPathParams(map[string]string{"uuid": sysAp.UUID, "serial": serial, "channel": channel, "datapoint": datapoint}).
 		SetBody(value).
@@ -280,7 +285,7 @@ func (sysAp *SystemAccessPoint) SetDatapoint(serial string, channel string, data
 // Returns:
 //   - *models.DeviceResponse: The response from the device if the action is successful.
 //   - error: An error if the request fails or the response cannot be parsed.
-func (sysAp *SystemAccessPoint) TriggerProxyDevice(class string, serial string, action string) (*models.DeviceResponse, error) {
+func (sysAp *SystemAccessPoint) TriggerProxyDevice(class, serial, action string) (*models.DeviceResponse, error) {
 	resp, err := sysAp.config.Client.R().
 		SetPathParams(map[string]string{"uuid": sysAp.UUID, "class": class, "serial": serial, "action": action}).
 		Get(sysAp.GetUrl("proxydevice/{uuid}/{class}/{serial}/action/{action}"))
@@ -299,7 +304,7 @@ func (sysAp *SystemAccessPoint) TriggerProxyDevice(class string, serial string, 
 // Returns:
 //   - *models.DeviceResponse: The response from the device if the operation is successful.
 //   - error: An error if the request fails or the response cannot be parsed.
-func (sysAp *SystemAccessPoint) SetProxyDeviceValue(class string, serial string, value string) (*models.DeviceResponse, error) {
+func (sysAp *SystemAccessPoint) SetProxyDeviceValue(class, serial, value string) (*models.DeviceResponse, error) {
 	resp, err := sysAp.config.Client.R().
 		SetPathParams(map[string]string{"uuid": sysAp.UUID, "class": class, "serial": serial, "value": value}).
 		Put(sysAp.GetUrl("proxydevice/{uuid}/{class}/{serial}/value/{value}"))

--- a/pkg/freeathome/system-access-point_test.go
+++ b/pkg/freeathome/system-access-point_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 )
 
+const (
+	errMsgExpectedNoLogOutputGot = "Expected no log output, got: %s"
+)
+
 // TestSystemAccessPointDefaultLogger tests the default logger functionality of SystemAccessPoint.
 func TestSystemAccessPointDefaultLogger(t *testing.T) {
 	// Create a buffer to capture log output
@@ -71,7 +75,7 @@ func TestSystemAccessPointGetHostName(t *testing.T) {
 	// Check if the log output is empty
 	logOutput := buf.String()
 	if logOutput != "" {
-		t.Errorf("Expected no log output, got: %s", logOutput)
+		t.Errorf(errMsgExpectedNoLogOutputGot, logOutput)
 	}
 
 	// Check if the actual host name matches the expected host name
@@ -90,7 +94,7 @@ func TestSystemAccessPointGetTlsEnabled(t *testing.T) {
 	// Check if the log output is empty
 	logOutput := buf.String()
 	if logOutput != "" {
-		t.Errorf("Expected no log output, got: %s", logOutput)
+		t.Errorf(errMsgExpectedNoLogOutputGot, logOutput)
 	}
 
 	// Check if the actual TLS enabled status matches the expected status
@@ -109,7 +113,7 @@ func TestSystemAccessPointGetSkipTLSVerify(t *testing.T) {
 	// Check if the log output is empty
 	logOutput := buf.String()
 	if logOutput != "" {
-		t.Errorf("Expected no log output, got: %s", logOutput)
+		t.Errorf(errMsgExpectedNoLogOutputGot, logOutput)
 	}
 
 	// Check if the actual skip TLS verify status matches the expected status
@@ -147,7 +151,7 @@ func TestSystemAccessPointGetVerboseErrors(t *testing.T) {
 	// Check if the log output is empty
 	logOutput := buf.String()
 	if logOutput != "" {
-		t.Errorf("Expected no log output, got: %s", logOutput)
+		t.Errorf(errMsgExpectedNoLogOutputGot, logOutput)
 	}
 
 	// Check if the actual verbose errors status matches the expected status
@@ -165,7 +169,7 @@ func TestSystemAccessPointGetUrlWithoutTls(t *testing.T) {
 	// Check if the log output is empty
 	logOutput := buf.String()
 	if logOutput != "" {
-		t.Errorf("Expected no log output, got: %s", logOutput)
+		t.Errorf(errMsgExpectedNoLogOutputGot, logOutput)
 	}
 
 	// Check if the actual URL matches the expected URL
@@ -184,7 +188,7 @@ func TestSystemAccessPointGetUrlWithTls(t *testing.T) {
 	// Check if the log output is empty
 	logOutput := buf.String()
 	if logOutput != "" {
-		t.Errorf("Expected no log output, got: %s", logOutput)
+		t.Errorf(errMsgExpectedNoLogOutputGot, logOutput)
 	}
 
 	// Check if the actual URL matches the expected URL

--- a/pkg/freeathome/system-access-point_test.go
+++ b/pkg/freeathome/system-access-point_test.go
@@ -38,11 +38,27 @@ func TestNoConfigErrors(t *testing.T) {
 // TestMustNewSystemAccessPoint tests that MustNewSystemAccessPoint panics when a nil config is passed to NewSystemAccessPoint.
 func TestMustNewSystemAccessPoint(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil {
+		if recover() == nil {
 			t.Errorf("Expected panic, got nil")
 		}
 	}()
 	MustNewSystemAccessPoint(nil)
+}
+
+func TestSystemAccessPointWebSocketRawOutputGetter(t *testing.T) {
+	sysAp, _, _ := setupSysAp(t, true, false)
+	if sysAp.GetWebSocketRawOutput() != nil {
+		t.Fatal("expected nil before set")
+	}
+	var buf bytes.Buffer
+	sysAp.SetWebSocketRawOutput(&buf)
+	if sysAp.GetWebSocketRawOutput() != &buf {
+		t.Fatal("getter should return configured writer")
+	}
+	sysAp.SetWebSocketRawOutput(nil)
+	if sysAp.GetWebSocketRawOutput() != nil {
+		t.Fatal("expected nil after clear")
+	}
 }
 
 // TestSystemAccessPointGetHostName tests the GetHostName method of SystemAccessPoint.


### PR DESCRIPTION
## Summary

Implements [#65](https://github.com/lion-and-bear/freeathome/issues/65): optional **`fh monitor --raw`** that streams each WebSocket text frame unchanged to **stdout** (newline-terminated), with user hints and slog output on **stderr** so pipes stay clean.

## Changes

- `Config.WebSocketRawOutput` + `SetWebSocketRawOutput` on `SystemAccessPoint`
- `processMessage`: early write of raw bytes + `\n`, skip datapoint parsing when set
- Skip per-frame debug log when raw output is enabled
- CLI: `--raw` flag; `hintOut` routes prompts to stderr in raw mode
- Tests, README, CHANGELOG ([Unreleased])

## Notion

User story: https://www.notion.so/334f4f62f09c8165a7a4ec5ff9ef3cfb

## Checklist

- [x] Tests pass locally (`go test ./...`)
